### PR TITLE
Merge lessons with same time into one

### DIFF
--- a/src/lib/models/course_lesson.dart
+++ b/src/lib/models/course_lesson.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: non_constant_identifier_names
 
+import 'package:fit_schedule_maker_plus/models/lesson_info.dart';
+
 enum DayOfWeek {
   monday,
   tueday,
@@ -27,24 +29,14 @@ class CourseLesson {
   final LessonType type;
   final DayOfWeek dayOfWeek;
 
-  /// Location of the lesson. For example: B/D105
-  final List<String> locations;
-  final int capacity;
-  /// Note attached to this lesson
-  final String note;
-  final String info;
-  // final String faculty; // Cannot scrape this info tho...
+  List<LessonInfo> infos;
 
   CourseLesson({
     required this.dayOfWeek,
     required this.type,
     required this.startsFrom,
     required this.endsAt,
-    required this.locations,
-    required this.note,
-    required this.info,
-    required this.capacity,
-    // required this.faculty,
+    required this.infos,
   });
 
   factory CourseLesson.fromJson(Map<String, dynamic> json) => CourseLesson(
@@ -52,11 +44,7 @@ class CourseLesson {
         endsAt: int.parse(json["ends_at"]),
         type: LessonType.values[int.parse(json["type"])],
         dayOfWeek: DayOfWeek.values[int.parse(json["day_of_week"])],
-        locations: json["locations"],
-        info: json["info"],
-        note: json["note"],
-        capacity: int.parse(json["capacity"]),
-        // faculty: json["faculty"],
+        infos: List<LessonInfo>.from(json["infos"].map((info) => LessonInfo.fromJson(info))),
       );
 
   Map<String, dynamic> toJson() => {
@@ -64,10 +52,6 @@ class CourseLesson {
         "ends_at": endsAt,
         "type": type.index,
         "day_of_week": dayOfWeek.index,
-        "locations": locations,
-        "capacity": capacity,
-        "info": info,
-        "note": note,
-        // "faculty": faculty,
+        "infos": List<dynamic>.from(infos.map((info) => info.toJson())),
       };
 }

--- a/src/lib/models/lesson_info.dart
+++ b/src/lib/models/lesson_info.dart
@@ -1,0 +1,34 @@
+// ignore_for_file: non_constant_identifier_names
+
+class LessonInfo {
+  /// Capacity of this lesson
+  final int capacity;
+  /// Weeks that have this lesson
+  final String weeks;
+  /// Info about the lesson
+  final String info;
+  /// Location of the lesson. For example: B/D105
+  final List<String> locations;
+
+  LessonInfo({
+    required this.locations,
+    required this.info,
+    required this.capacity,
+    required this.weeks,
+  });
+
+  factory LessonInfo.fromJson(Map<String, dynamic> json) => LessonInfo(
+        locations: json["locations"],
+        info: json["info"],
+        weeks: json["weeks"],
+        capacity: int.parse(json["capacity"]),
+      );
+
+  Map<String, dynamic> toJson() => {
+        "locations": locations,
+        "capacity": capacity,
+        "info": info,
+        "weeks": weeks,
+      };
+}
+

--- a/src/lib/viewmodels/app.dart
+++ b/src/lib/viewmodels/app.dart
@@ -194,6 +194,7 @@ class AppViewModel extends ChangeNotifier {
       if (value.dayOfWeek != lesson.dayOfWeek
         || value.startsFrom != lesson.startsFrom
         || value.endsAt != lesson.endsAt
+        || value.type != lesson.type
       ) {
         continue;
       }

--- a/src/lib/viewmodels/app.dart
+++ b/src/lib/viewmodels/app.dart
@@ -1,5 +1,6 @@
 import 'package:fit_schedule_maker_plus/models/course.dart';
 import 'package:fit_schedule_maker_plus/models/course_lesson.dart';
+import 'package:fit_schedule_maker_plus/models/lesson_info.dart';
 import 'package:fit_schedule_maker_plus/models/study.dart';
 import 'package:fit_schedule_maker_plus/models/program_course_group.dart';
 import 'package:fit_schedule_maker_plus/models/program_course.dart';
@@ -176,11 +177,37 @@ class AppViewModel extends ChangeNotifier {
     allCourses[courseId]!.lessons = parser
         .querySelectorAll("#schedule tbody tr")
         .map(_parseLesson)
-        .where((value) => value != null)
-        .map((value) => value!)
-        .toList();
+        .fold(<CourseLesson>[], _mergeSameLessons);
 
     allCourses[courseId]!.loadedLessons = true;
+  }
+
+  List<CourseLesson> _mergeSameLessons(List<CourseLesson> list, CourseLesson? lesson) {
+    if (lesson == null) {
+      return list;
+    }
+
+    bool found = false;
+
+    for (var i = 0; i < list.length; i++) {
+      final value = list[i];
+      if (value.dayOfWeek != lesson.dayOfWeek
+        || value.startsFrom != lesson.startsFrom
+        || value.endsAt != lesson.endsAt
+      ) {
+        continue;
+      }
+
+      list[i].infos.addAll(lesson.infos);
+      found = true;
+      break;
+    }
+
+    if (!found) {
+      list.add(lesson);
+    }
+
+    return list;
   }
 
   CourseLesson? _parseLesson(element) {
@@ -230,20 +257,17 @@ class AppViewModel extends ChangeNotifier {
 
     if (startsFrom == null || endsAt == null || capacity == null) return null;
 
-    final note = matches[2];
+    final weeks = matches[2];
     final info = exp.firstMatch(matches.last!)![1];
 
-    if (note == null || info == null) return null;
+    if (weeks == null || info == null) return null;
 
     return CourseLesson(
       dayOfWeek: dayOfWeek,
       type: type,
-      locations: locations,
-      note: note,
-      info: info,
+      infos: [LessonInfo(locations: locations, info: info, weeks: weeks, capacity: capacity)],
       startsFrom: startsFrom,
       endsAt: endsAt,
-      capacity: capacity,
     );
   }
 


### PR DESCRIPTION
Changes made:

- Renamed `note` to `weeks`
- Moved `weeks`, `info`, `locations`, `capacity` from `CourseLesson` to a new object `LessonInfo`
- `CourseLesson` now contains a `List<LessonInfo>` that may have multiple pieces of information for that one lesson