### PR TITLE
Add `CousePrerequisite` to the API

### DIFF
--- a/src/lib/models/course.dart
+++ b/src/lib/models/course.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: non_constant_identifier_names
 
 import 'package:fit_schedule_maker_plus/models/course_lesson.dart';
+import 'package:fit_schedule_maker_plus/models/course_prerequisite.dart';
 
 import 'program_course_group.dart';
 
@@ -11,15 +12,17 @@ class Course {
   final String fullName;
   final Semester semester;
   List<CourseLesson> lessons;
-  bool loadedLessons;
+  List<CoursePrerequisite> prerequisites;
+  bool loaded;
 
   Course({
     required this.id,
     required this.fullName,
     required this.shortcut,
     required this.lessons,
+    required this.prerequisites,
     required this.semester,
-    required this.loadedLessons,
+    this.loaded = false,
   });
 
   factory Course.fromJson(Map<String, dynamic> json) => Course(
@@ -28,7 +31,8 @@ class Course {
         fullName: json["fullName"],
         semester: json["semester"],
         lessons: List<CourseLesson>.from(json["lessons"].map((lesson) => CourseLesson.fromJson(lesson))),
-        loadedLessons: false,
+        prerequisites: List<CoursePrerequisite>.from(json["prerequisites"].map((prerequisite) => CoursePrerequisite.fromJson(prerequisite))),
+        loaded: false,
       );
 
   Map<String, dynamic> toJson() => {
@@ -37,5 +41,6 @@ class Course {
         "fullName": fullName,
         "semester": semester,
         "lessons": List<dynamic>.from(lessons.map((lesson) => lesson.toJson())),
+        "prerequisites": List<dynamic>.from(prerequisites.map((prerequisite) => prerequisite.toJson())),
       };
 }

--- a/src/lib/models/course_prerequisite.dart
+++ b/src/lib/models/course_prerequisite.dart
@@ -1,0 +1,43 @@
+// ignore_for_file: non_constant_identifier_names
+
+enum PrerequisiteType {
+  lecture,
+  seminar,
+  laborator,
+  exercise,
+  project,
+  pcLab,
+}
+
+class CoursePrerequisite {
+  /// number of required hours for this type of prerequisite
+  final int requiredHours;
+  /// Number of lessons for during the course
+  final int numberOfLessons;
+  /// Type of the prerequisite
+  final PrerequisiteType type;
+
+  CoursePrerequisite({
+    required this.requiredHours,
+    required this.numberOfLessons,
+    required this.type,
+  });
+
+  /// Calculate the estimated hours per week for this prerequisite during the course
+  int hoursPerWeek() {
+    if (numberOfLessons == 0) return 0;
+    return (requiredHours / numberOfLessons).floor();
+  }
+
+  factory CoursePrerequisite.fromJson(Map<String, dynamic> json) => CoursePrerequisite(
+        requiredHours: int.parse(json["required_hours"]),
+        numberOfLessons: int.parse(json["number_of_lessons"]),
+        type: PrerequisiteType.values[int.parse(json["type"])],
+      );
+
+  Map<String, dynamic> toJson() => {
+        "required_hours": requiredHours,
+        "number_of_lessons": numberOfLessons,
+        "type": type.index,
+      };
+}


### PR DESCRIPTION
Changes made:
- Added `CoursePrerequisite` in `src/lib/models/course_prerequisite.dart`
    - `Course` now has property `prerequisites`
- Renamed `getCourseLession` to `getCourseData` since it now scrapes both lessons and prerequisites ~~and I didn't realize there was a typo there~~